### PR TITLE
Fix backgrounds path

### DIFF
--- a/index.html
+++ b/index.html
@@ -222,12 +222,16 @@
                 { imageUrl: "img/gallery/artwork5.jpg", description: "Artwork 5" },  
                 { imageUrl: "img/gallery/artwork6.jpg", description: "Artwork 6" },
             ],
+            // Use existing gallery images as rotating page backgrounds
+            // Previously this referenced a non-existent `img/backgrounds` folder
+            // which caused broken background URLs.
             backgroundImages: [
-                'img/backgrounds/bg1.jpg',
-                'img/backgrounds/bg2.jpg',
-                'img/backgrounds/bg3.jpg',
-                'img/backgrounds/bg4.jpg',
-                'img/backgrounds/bg5.jpg'  
+                'img/gallery/artwork1.jpg',
+                'img/gallery/artwork2.jpg',
+                'img/gallery/artwork3.jpg',
+                'img/gallery/artwork4.jpg',
+                'img/gallery/artwork5.jpg',
+                'img/gallery/artwork6.jpg'
             ],
             footerInfo: { 
                 text: "Ferox. All rights reserved.",


### PR DESCRIPTION
## Summary
- fix bug where background images referenced non-existent `img/backgrounds` path
- use existing gallery images for background slideshow

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683f4f5a95ec832a86fc51b217f75f6c