### PR TITLE
Update footer year explanation

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,4 +4,4 @@ This repository contains a small personal page built with React. The content con
 
 ## Footer year
 
-The footer displays the current year dynamically. Historically this value was set in a function called `loadDynamicContent()` which populated various elements. The call to `initializeFooterYear()` remains in the codebase as a placeholder in case additional logic is needed in the future. At runtime the year is already injected through `loadDynamicContent()` so the placeholder call performs no work.
+The footer displays the current year dynamically using `new Date().getFullYear()` directly in the React component. The `initializeFooterYear()` function remains as a no-op placeholder for any future footer logic.

--- a/js/app.js
+++ b/js/app.js
@@ -168,9 +168,9 @@ function App() {
 ReactDOM.render(React.createElement(App), document.getElementById('root'));
 
 function initializeFooterYear() {
-    // Placeholder: the footer year is set in loadDynamicContent(),
-    // so this function currently does nothing.
+    // The footer year is inserted directly in the React component using
+    // new Date().getFullYear(), so this function currently does nothing.
 }
 
-initializeFooterYear(); // Placeholder call pending future year logic
+initializeFooterYear(); // Placeholder call pending future footer logic
 


### PR DESCRIPTION
## Summary
- clarify in README that the footer year comes from `new Date().getFullYear()`
- update `initializeFooterYear()` comment to match new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683fc4b56370832a8efa4daca0fb7cdb