### PR TITLE
Improve gallery layout and lightbox controls

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -120,26 +120,25 @@ body.light {
   grid-template-columns: 1fr;
   gap: 1.5rem; /* Tailwind's gap-6 */
 }
-  .gallery-card {
-    transition:
-      transform 0.3s ease,
-      box-shadow 0.3s ease;
-    width: 300px;
-    height: 300px;
-    position: relative;
-    margin: 0 auto;
-  }
-  .gallery-card:hover {
-    transform: translateY(-5px);
-    box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
-  }
+.gallery-card {
+  transition:
+    transform 0.3s ease,
+    box-shadow 0.3s ease;
+  width: 100%;
+  position: relative;
+  margin: 0 auto;
+}
+.gallery-card:hover {
+  transform: translateY(-5px);
+  box-shadow: 0 10px 20px rgba(0, 0, 0, 0.25);
+}
 
-  .gallery-card img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-    display: block;
-  }
+.gallery-card img {
+  width: 100%;
+  height: auto;
+  object-fit: contain;
+  display: block;
+}
 
 .loading-skeleton {
   background-color: #334155;
@@ -221,6 +220,17 @@ body.light {
   position: absolute;
   top: 50%;
   transform: translateY(-50%);
+  background-color: rgba(0, 0, 0, 0.6);
+  color: #fff;
+  border: none;
+  font-size: 2rem;
+  width: 3rem;
+  height: 3rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 9999px;
+  cursor: pointer;
 }
 .lightbox-prev {
   left: 1rem;


### PR DESCRIPTION
## Summary
- tweak gallery cards for fluid layout and prevent image cropping
- style lightbox navigation buttons for better visibility

## Testing
- `npm run lint --silent`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_684007541d24832a843f558de8a818c5