### PR TITLE
Fix dynamic config loading

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -46,7 +46,7 @@ function ImageWithLoader(props) {
   );
 }
 
-const userConfig = {
+const DEFAULT_CONFIG = {
   profileImageUrl: 'img/profile.jpg',
   welcomeMessageText: 'Ferox',
   socialMediaLinks: [
@@ -143,8 +143,14 @@ const userConfig = {
 };
 
 function App() {
+  const [userConfig, setUserConfig] = useState(DEFAULT_CONFIG);
+
   useEffect(() => {
     document.body.classList.add('dark');
+    fetch('data/config.json')
+      .then((res) => (res.ok ? res.json() : Promise.reject(res.status)))
+      .then(setUserConfig)
+      .catch((err) => console.error('Failed to load config.json', err));
   }, []);
 
   const [showToTop, setShowToTop] = useState(false);

--- a/sw.js
+++ b/sw.js
@@ -3,7 +3,9 @@ const ASSETS = [
   '/',
   'index.html',
   'css/style.css',
+  'css/tailwind.css',
   'js/app.js',
+  'js/main.js',
   'data/config.json'
 ];
 self.addEventListener('install', event => {


### PR DESCRIPTION
## Summary
- load runtime configuration from `data/config.json`
- keep a fallback DEFAULT_CONFIG in the bundle
- cache more files in `sw.js`

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684009bbffd4832a999295f9b52f2512