### PR TITLE
Improve mobile performance

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -186,7 +186,7 @@ function App() {
   useEffect(() => {
     const handleScroll = () =>
       setShowToTop(window.scrollY > SCROLL_OFFSET_SHOW_TO_TOP);
-    window.addEventListener('scroll', handleScroll);
+    window.addEventListener('scroll', handleScroll, { passive: true });
     return () => window.removeEventListener('scroll', handleScroll);
   }, []);
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,8 @@
 document.addEventListener('DOMContentLoaded', () => {
   import('./app.js');
-  import('./air-trail.js');
+  if (window.matchMedia('(hover: hover) and (pointer: fine)').matches) {
+    import('./air-trail.js');
+  }
 
   const bg = document.getElementById('bgSlideshow');
   const hero = document.getElementById('hero');


### PR DESCRIPTION
## Summary
- make scroll event listener passive
- skip the heavy air trail effect on mobile by checking pointer/hover

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684175fadf40832a9f3c3af2f21e1aa2