### PR TITLE
Improve interactive air-trail effect

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -61,6 +61,17 @@ body.light {
   position: relative;
   z-index: 1;
 }
+
+/* Canvas overlay for interactive air trail */
+#airTrail {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 2;
+}
 /* Scroll cue arrow */
 .scroll-cue {
   width: 32px;

--- a/index.html
+++ b/index.html
@@ -49,6 +49,18 @@
   <body class="text-slate-100">
     <div id="bgSlideshow"></div>
     <div class="overlay"></div>
+    <canvas
+      id="airTrail"
+      style="
+        position: fixed;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+        pointer-events: none;
+        z-index: 2;
+      "
+    ></canvas>
     <div id="root" class="content-container container mx-auto px-4 py-8"></div>
 
     <script

--- a/js/air-trail.js
+++ b/js/air-trail.js
@@ -1,0 +1,116 @@
+(() => {
+  const canvas = document.getElementById('airTrail');
+  if (!canvas || !window.PointerEvent) return;
+
+  const ctx = canvas.getContext('2d');
+  const dpr = window.devicePixelRatio || 1;
+  let w;
+  let h;
+
+  function resize() {
+    canvas.width = window.innerWidth * dpr;
+    canvas.height = window.innerHeight * dpr;
+    canvas.style.width = '100%';
+    canvas.style.height = '100%';
+    w = canvas.width / dpr;
+    h = canvas.height / dpr;
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  }
+  resize();
+
+  window.addEventListener('resize', resize, { passive: true });
+
+  class Particle {
+    constructor(x, y, vx, vy) {
+      this.x = x;
+      this.y = y;
+      this.vx = vx;
+      this.vy = vy;
+      this.life = 1;
+    }
+    update(dt, decay) {
+      this.x += this.vx * dt;
+      this.y += this.vy * dt;
+      this.life -= decay * dt;
+      return this.life > 0;
+    }
+    draw() {
+      ctx.globalAlpha = this.life;
+      ctx.beginPath();
+      ctx.moveTo(this.x, this.y);
+      ctx.lineTo(this.x - this.vx * 2, this.y - this.vy * 2);
+      ctx.stroke();
+    }
+  }
+
+  let particles = [];
+  let last = 0;
+  let scrollFactor = 1;
+  let lastX;
+  let lastY;
+  let lastScroll = 0;
+
+  function onMove(e) {
+    if (lastX === undefined) {
+      lastX = e.clientX;
+      lastY = e.clientY;
+    }
+    const vx = e.clientX - lastX;
+    const vy = e.clientY - lastY;
+    particles.push(new Particle(e.clientX, e.clientY, vx, vy));
+    if (particles.length > 600) particles.shift();
+    lastX = e.clientX;
+    lastY = e.clientY;
+  }
+
+  function resetPointer() {
+    lastX = undefined;
+    lastY = undefined;
+  }
+
+  window.addEventListener(
+    'pointerdown',
+    (e) => {
+      lastX = e.clientX;
+      lastY = e.clientY;
+    },
+    { passive: true },
+  );
+  window.addEventListener('pointermove', onMove, { passive: true });
+  window.addEventListener('pointerup', resetPointer, { passive: true });
+  window.addEventListener('pointercancel', resetPointer, { passive: true });
+  window.addEventListener(
+    'scroll',
+    () => {
+      scrollFactor = 2;
+      lastScroll = performance.now();
+    },
+    { passive: true },
+  );
+
+  ctx.strokeStyle = 'rgba(255,255,255,0.8)';
+  ctx.lineWidth = 2 * dpr;
+  ctx.lineCap = 'round';
+
+  function loop(time) {
+    const dt = (time - last) / 16.7;
+    last = time;
+    ctx.clearRect(0, 0, w, h);
+    if (document.visibilityState === 'hidden') {
+      requestAnimationFrame(loop);
+      return;
+    }
+    const elapsed = time - lastScroll;
+    scrollFactor = 1 + Math.max(0, 1.5 - elapsed / 200);
+    const decay = 0.05 * scrollFactor;
+    particles = particles.filter((p) => {
+      if (p.update(dt, decay)) {
+        p.draw();
+        return true;
+      }
+      return false;
+    });
+    requestAnimationFrame(loop);
+  }
+  requestAnimationFrame(loop);
+})();

--- a/js/main.js
+++ b/js/main.js
@@ -1,11 +1,12 @@
 document.addEventListener('DOMContentLoaded', () => {
   import('./app.js');
+  import('./air-trail.js');
 
   const bg = document.getElementById('bgSlideshow');
   const hero = document.getElementById('hero');
   const preloadSrc = 'https://placehold.co/1920x1080.webp';
 
-  const observer = new IntersectionObserver(entries => {
+  const observer = new IntersectionObserver((entries) => {
     if (entries[0].isIntersecting) {
       bg.style.backgroundImage = `url('${preloadSrc}')`;
       observer.disconnect();


### PR DESCRIPTION
## Summary
- refine `air-trail.js` to use the existing canvas element
- compute particle velocity manually and reset on pointer end
- accelerate fade-out on scroll and stop drawing when the tab is hidden

## Testing
- `npm run lint`
- `npm run format`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6841743e9094832aa91766347c9a1b9e