### PR TITLE
Fix content security policy for external scripts

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,9 +4,13 @@ const cors = require('cors');
 
 const app = express();
 app.use(cors());
-app.use(helmet({
-  crossOriginResourcePolicy: false
-}));
+app.use(
+  helmet({
+    crossOriginResourcePolicy: false,
+    // Disable the default CSP so the meta tag in index.html controls it.
+    contentSecurityPolicy: false,
+  }),
+);
 
 app.use(helmet.frameguard({ action: 'deny' }));
 app.use(helmet.referrerPolicy({ policy: 'strict-origin-when-cross-origin' }));


### PR DESCRIPTION
## Summary
- disable Helmet's default Content Security Policy
- rely on the meta tag policy so React and other scripts load

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684221c51e74832a977b95d474fa3da7